### PR TITLE
Styling for chat dash in mobile view and chat buttons

### DIFF
--- a/src/components/ChatScreen.js
+++ b/src/components/ChatScreen.js
@@ -89,7 +89,7 @@ class ChatScreen extends React.Component {
           tickets={chat.tickets}
           guest={chat.guest}
         />
-        {chat.typingUser ? <p>{chat.typingUser.name} is typing</p> : null}
+        {chat.typingUser ? <p className="typing">{chat.typingUser.name} is typing...</p> : null}
         {ACTIVE === status ? (
           <React.Fragment>
             <MessageComposer
@@ -168,6 +168,11 @@ const StyledChatScreen = styled.div`
   justify-content: space-between;
   height: 100%;
   background-color: ${theme.color.white};
+  .typing {
+    font-size: ${theme.fontSize.message};
+    font-style: italic;
+    padding-left: 1rem;
+  }
 `;
 
 const StyledChatButtons = styled.div`

--- a/src/components/ChatScreen.js
+++ b/src/components/ChatScreen.js
@@ -7,7 +7,6 @@ import theme from '../theme/styledTheme';
 import Messages from './Messages';
 import ChatScreenHeader from './ChatScreenHeader';
 import MessageComposer from './MessageComposer';
-import Button from '@material-ui/core/Button';
 import { SOCKET } from '../utils/paths';
 import { ACTIVE, QUEUED } from '../utils/ticketStatus';
 import {
@@ -98,15 +97,21 @@ class ChatScreen extends React.Component {
               last_ticket_id={lastTicket._id}
               language={lastTicket.language}
             />
-            <Button onClick={this.closeTicket}>Close Ticket</Button>
-            <Button onClick={this.translateMessage}>Translate</Button>
+            <StyledChatButtons>
+              <button onClick={this.closeTicket}>Close Ticket</button>
+              <button onClick={this.translateMessage}>Translate</button>
+            </StyledChatButtons>
+
           </React.Fragment>
         ) : null}
         {QUEUED === status ? (
           <React.Fragment>
-            <StyledJoinButton onClick={this.joinChat}>
-              Join Chat
+            <StyledJoinButton>
+              <button onClick={this.joinChat}>
+                Join Chat
+              </button>
             </StyledJoinButton>
+
           </React.Fragment>
         ) : null}
 
@@ -165,15 +170,54 @@ const StyledChatScreen = styled.div`
   background-color: ${theme.color.white};
 `;
 
-const StyledJoinButton = styled.button`
-  margin: 2rem;
-  border-radius: 0.5rem;
-  background-color: ${theme.color.accentGreen};
-  color: ${theme.color.white};
-  font-weight: ${theme.fontWeight.bolder};
-  width: 95%;
-  align-item: center;
-  padding: 1.5rem;
+const StyledChatButtons = styled.div`
+  button {
+    width: 100%;
+    height: ${theme.button.smallButton};
+    font-size: ${theme.fontSize.xxs};
+    border-radius: ${theme.border.radius};
+    background: ${theme.color.accentGreen};
+    border: none;
+    text-transform: ${theme.textTransform.uppercase};
+    color: ${theme.color.white};
+    font-weight: ${theme.fontWeight.bold};
+    margin-bottom: 15px;
+    box-shadow: ${theme.shadow.buttonShadow};
+    &:hover {
+      box-shadow: ${theme.shadow.buttonHover};
+      cursor: pointer;
+      transition: all 0.3s ease;
+    }
+    &:focus {
+      outline: none;
+    }
+    &:last-child {
+     margin: 0;
+    }
+    @media (max-width: 800px) {
+    height: ${theme.button.height};
+    font-size: ${theme.fontSize.xs};
+    }
+  }
+`;
+
+const StyledJoinButton = styled.div`
+  button {
+  margin-top: 1.5rem;
+    border-radius: 5px;
+    background-color: ${theme.color.accentGreen};
+    color: ${theme.color.white};
+    font-weight: ${theme.fontWeight.bold};
+    font-size: ${theme.fontSize.xxs};
+    width: 100%;
+    align-item: center;
+    height: ${theme.button.smallButton};
+    text-transform: uppercase;
+    @media (max-width: 800px) {
+      font-size: ${theme.fontSize.xs};
+      height: ${theme.button.height};
+    }
+  }
 `;
 export default connect(
   mapStateToProps,

--- a/src/components/ChatScreenHeader.js
+++ b/src/components/ChatScreenHeader.js
@@ -6,7 +6,7 @@ import theme from '../theme/styledTheme';
 function ChatScreenHeader({ guest_name, room_name }) {
   return (
     <StyledChatScreenHeader>
-      <p>Guest Name:{guest_name}</p>
+      <p>Guest Name: {guest_name}</p>
       <p>Room: {room_name}</p>
     </StyledChatScreenHeader>
   );
@@ -18,11 +18,12 @@ ChatScreenHeader.propTypes = {
 };
 
 const StyledChatScreenHeader = styled.div`
-  border: 2px solid ${theme.color.footerText};
-  padding: 0.3125rem;
-  background-color: ${theme.color.footerText};
+  font-size: ${theme.fontSize.message};
+  border-radius: 5px;
+  padding: 0.5rem 1rem ;
+  background: ${theme.color.footerText};
   height: 5vh;
-  min-height: 40px;
+  min-height: 50px;
 `;
 
 export default ChatScreenHeader;

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -6,7 +6,7 @@ import theme from '../theme/styledTheme';
 function Message({ message, guest_id }) {
   return (
     <StyledMessage left={guest_id === message.sender.id}>
-      <span>{message.sender.name} : </span>
+      <span className="sender-name">{message.sender.name} : </span>
       <div className="bubble-container">
         <span className="bubble me">{message.text}</span>
       </div>
@@ -26,12 +26,16 @@ Message.propTypes = {
 };
 
 const StyledMessage = styled.div`
-  margin: 1.25rem;
+  margin: 1.25rem 1rem;
   position: relative;
   max-width: 65%;
   border-radius: 2em;
   padding: 2rem;
-
+  font-size: ${theme.fontSize.message};
+  line-height: 1.25;
+  .sender-name {
+    font-weight: bold;
+  }
 
   ${props =>
     props.left

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -41,7 +41,7 @@ const StyledMessage = styled.div`
     props.left
       ? `background:${theme.color.lightPurple};`
       : `background:${theme.color.footerText};`}
-  /* ${props => (props.left ? `text-align: left;` : 'text-align: right;')} */
+  ${props => (props.left ? `text-align: left;` : 'text-align: right;')}
   ${props => (props.left ? `margin-right:auto;` : 'margin-left:auto;')}
   &:after {
     content: '';

--- a/src/components/MessageComposer.js
+++ b/src/components/MessageComposer.js
@@ -4,8 +4,6 @@ import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { SOCKET } from '../utils/paths';
-import Input from '@material-ui/core/Input';
-import Button from '@material-ui/core/Button';
 import { translate } from '../store/actions/chat';
 import theme from '../theme/styledTheme'
 
@@ -64,15 +62,15 @@ class MessageComposer extends React.Component {
   render() {
     return (
       <StyledMessageComposer>
-        <Input
+        <input
           value={this.state.inputValue}
           onChange={this.handleInput}
           className="flex"
         />
         <StyledMessageComposerSendButton onClick={this.handleSend}>
-        <span  className="fas fa-paper-plane"></span>
+        <span  className="fas fa-paper-plane" />
         </StyledMessageComposerSendButton>
-        <Button onClick={() => this.translateSend()}>Translate & Send</Button>
+        <button className="translate-and-send" onClick={() => this.translateSend()}>Translate & Send</button>
       </StyledMessageComposer>
     );
   }
@@ -89,23 +87,72 @@ const StyledMessageComposer = styled.div`
   display: flex;
   width: 100%;
   justify-content: stretch;
+  align-items: center;
   .flex {
     flex: 1;
+  }
+  input {
+    border: none;
+    border-bottom: 1px solid ${theme.color.footerText};
+    margin-bottom: 20px;
+    height: ${theme.input.height};
+    font-size: ${theme.fontSize.message};
+    padding: 20px 0;
+    border-radius: 0;
+    &:focus {
+      outline: none;
+    }
+  }
+  
+  .translate-and-send {
+    border: none;
+    border-radius: 5px;
+    background: ${theme.color.accentPurple};
+    color: ${theme.color.white};
+    font-weight: bold;
+    font-size: ${theme.fontSize.xxs};
+    height: ${theme.button.smallButton};
+    text-transform: uppercase;
+
+    &:focus {
+      outline: none;
+    }
+    
+    &:hover {
+    cursor: pointer;
+    box-shadow: ${theme.shadow.buttonHover};
+    transition: all 0.3s ease;
+    }
   }
 
 `;
 const StyledMessageComposerSendButton = styled.button`
-color: ${theme.color.footerText};
-border:none
-&:hover{
-  background:transparent;
-}
-&:focus {
-  outline: -webkit-focus-ring-color auto 5px;
-  outline-color: -webkit-focus-ring-color;
-  outline-style: auto;
-  outline-width: 0;
-}
+  border: none;
+  background: none;
+  &:focus {
+    outline: none;
+  }
+  
+  button {
+    border: none;
+    background: none;
+    text-transform: uppercase;
+    &:focus {
+      outline: none;
+    }
+  }
+  
+  .fa-paper-plane {
+    background: none;
+    background: transparent;
+    color: ${theme.color.accentGreen};
+    font-size: ${theme.fontSize.m};
+    cursor: pointer;
+    &:hover {
+      color: ${theme.color.accentPurple};
+      transition: all 0.3s ease;
+    }
+  }
 `;
 
 // need to get the socket here to emit connect props

--- a/src/components/Messages.js
+++ b/src/components/Messages.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import propTypes from 'prop-types';
+import theme from './.././theme/styledTheme';
 
 import Message from './Message';
 import RatingMessage from './RatingMessage';
@@ -75,6 +76,14 @@ Messages.propTypes = {
 
 const StyledMessages = styled.div`
   overflow-y: scroll;
+    margin-top: 1.5rem;
+  
+  div {
+    p {
+      font-size: ${theme.fontSize.message};
+      margin: 0 1rem;
+    }
+  }
 `;
 
 export default Messages;

--- a/src/components/chat/SearchInput.js
+++ b/src/components/chat/SearchInput.js
@@ -18,7 +18,7 @@ const StyledInput = styled.input`
   border-bottom: 1px solid ${theme.color.footerText};
   margin: 20px 0;
   height: ${theme.input.height};
-  font-size: ${theme.fontSize.xxs};
+  font-size: ${theme.fontSize.message};
   padding: 20px 0;
   border-radius: 0;
   &:focus {

--- a/src/components/chat/TicketView.js
+++ b/src/components/chat/TicketView.js
@@ -38,7 +38,7 @@ const TicketView = ({
                   return (
                     <div key={ticket._id}>
                       <div>
-                        Last message:
+                        Last message:<span/>
                         {ticket.messages[ticket.messages.length - 1].text}
                       </div>
                     </div>
@@ -77,7 +77,11 @@ const StyledDiv = styled.div`
   border-radius: 4px;
   color: white;
   font-weight: ${theme.fontWeight.light};
-  font-size: ${theme.fontSize.xxs};
+  font-size: ${theme.fontSize.message};
+  
+  span {
+    padding-left: 5px;
+  }
   &:hover {
     cursor: pointer;
     background: ${theme.color.hoverPurple};

--- a/src/components/reusable/Tabs.js
+++ b/src/components/reusable/Tabs.js
@@ -24,6 +24,7 @@ const StyledTabs = styled.div`
   @media (max-width: 600px) {
     flex-direction: column;
     width: 100%;
+    padding-top: 30px;
   }
   .tab {
     text-decoration: none;
@@ -48,6 +49,7 @@ const StyledTabs = styled.div`
     @media (max-width: 600px) {
       width: 100%;
       background: ${theme.color.lightPurple};
+      margin: 0;
       margin-bottom: 1rem;
       &.selected {
         border-bottom: 2px solid ${theme.color.accentGreen};

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,7 @@ html {
   font-size: 62.5%;
 }
 
-h1, h2, h3, h4, h5, h6, p, a, li, input, form, label {
+h1, h2, h3, h4, h5, h6, p, a, li, input, form, label, span {
   font-family: 'Lato', sans-serif;
   line-height: 1.5;
   letter-spacing: 0.1rem;

--- a/src/theme/styledTheme.js
+++ b/src/theme/styledTheme.js
@@ -30,6 +30,7 @@ const theme = {
   fontSize: {
     xxxs: '0.875rem',
     xxs: '1.2rem',
+    message: '1.4rem',
     xs: '1.6rem',
     s: '1.8rem',
     sm: '2rem',


### PR DESCRIPTION
# Description


- Fixed an issue where the chat list was jumping off the screen in mobile view after removing a media query which set the hight to 100%.
- Styled buttons on the chat side
- Styled when a guest is typing
- Added a new font size to the theme and changed all text on the chat view that was previously set at 12px to 14px.
- Added transitions for buttons on the chat view.

Fixes #172 #183



## Type of change



Please delete options that are not relevant.



- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] This change requires a documentation update



## Change status



- [ ] Complete, tested, ready to review and merge

- [x] Complete, but not tested (may need new tests)

- [ ] Incomplete/work-in-progress, PR is for discussion/feedback



# How Has This Been Tested?



Please describe steps taken to ensure this feature is functional and does not break other features:
Tested in the browser


# Checklist:



- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation, if relevant

- [x] I have run the app using my feature and ensured that no functionality is broken

- [x] My changes generate no new warnings

- [x] There are no merge conflicts
